### PR TITLE
[add-ws-handshake-error-hook]: Add WS handshake error hook.

### DIFF
--- a/src/main/java/org/java_websocket/WebSocketAdapter.java
+++ b/src/main/java/org/java_websocket/WebSocketAdapter.java
@@ -32,6 +32,10 @@ public abstract class WebSocketAdapter implements WebSocketListener {
 	public void onWebsocketHandshakeReceivedAsClient( WebSocket conn, ClientHandshake request, ServerHandshake response ) throws InvalidDataException {
 	}
 
+	@Override
+	public void onWebsocketHandshakeError( WebSocket conn, ClientHandshake request, ServerHandshake response ) {
+	}
+
 	/**
 	 * This default implementation does not do anything which will cause the connections to always progress.
 	 * 

--- a/src/main/java/org/java_websocket/WebSocketImpl.java
+++ b/src/main/java/org/java_websocket/WebSocketImpl.java
@@ -287,6 +287,7 @@ public class WebSocketImpl implements WebSocket {
 						open( handshake );
 						return true;
 					} else {
+						wsl.onWebsocketHandshakeError( this, handshakerequest, handshake );
 						close( CloseFrame.PROTOCOL_ERROR, "draft " + draft + " refuses handshake" );
 					}
 				}

--- a/src/main/java/org/java_websocket/WebSocketListener.java
+++ b/src/main/java/org/java_websocket/WebSocketListener.java
@@ -123,6 +123,19 @@ public interface WebSocketListener {
 	public void onWebsocketError( WebSocket conn, Exception ex );
 
 	/**
+	 * Called on the client side when the connection fails to complete the
+	 * handshake.
+	 * 
+	 * @param conn
+	 *            The WebSocket related to this event
+	 * @param request
+	 *            The handshake initially send out to the server by this websocket.
+	 * @param response
+	 *            The handshake the server sent in response to the request.
+	 */
+	public void onWebsocketHandshakeError( WebSocket conn, ClientHandshake request, ServerHandshake response );
+
+	/**
 	 * Called a ping frame has been received.
 	 * This method must send a corresponding pong by itself.
 	 * 


### PR DESCRIPTION
This adds a new hook to the websocket interface for capturing
information on a failed handshake. Used in ACE to record the server sent
reconnect delay, if present.

This is my attempt to address some of the concerns raised for https://github.com/Ubiquiti-UniFi/Java-WebSocket/pull/1 with the hope of having the same end result. I have not attempted to pull in upstream changes here. If desired, I can do that in a separate PR, but didn't want to conflate the two problems.

@ubnt-yhlee Tagging YH for review, uncertain who else to include for review.